### PR TITLE
decoder: fix support for h264 baseline profile

### DIFF
--- a/src/ffvadecoder.c
+++ b/src/ffvadecoder.c
@@ -338,6 +338,8 @@ vaapi_get_format(AVCodecContext *avctx, const enum AVPixelFormat *pix_fmts)
     case VAProfileMPEG4AdvancedSimple:
         profiles[num_profiles++] = VAProfileMPEG4Main;
         break;
+    case VAProfileH264Baseline:
+        // fall-through
     case VAProfileH264ConstrainedBaseline:
         profiles[num_profiles++] = VAProfileH264Main;
         // fall-through


### PR DESCRIPTION
Environment ubuntu 14.04
CPU:i5-2410m
My va_info is as follows:

```
libva info: VA-API version 0.37.0
libva info: va_getDriverName() returns 0
libva info: Trying to open /usr/local/lib/dri/i965_drv_video.so
libva info: Found init function __vaDriverInit_0_35
libva info: va_openDriver() returns 0
vainfo: VA-API version: 0.37 (libva 1.5.1)
vainfo: Driver version: Intel i965 driver - 1.3.0
vainfo: Supported profile and entrypoints
      VAProfileMPEG2Simple            : VAEntrypointVLD
      VAProfileMPEG2Main              : VAEntrypointVLD
      VAProfileH264ConstrainedBaseline: VAEntrypointVLD
      VAProfileH264ConstrainedBaseline: VAEntrypointEncSlice
      VAProfileH264Main               : VAEntrypointVLD
      VAProfileH264Main               : VAEntrypointEncSlice
      VAProfileH264High               : VAEntrypointVLD
      VAProfileH264High               : VAEntrypointEncSlice
      VAProfileVC1Simple              : VAEntrypointVLD
      VAProfileVC1Main                : VAEntrypointVLD
      VAProfileVC1Advanced            : VAEntrypointVLD
      VAProfileNone                   : VAEntrypointVideoProc
```

And VAProfileH264Baseline is not found. Maybe it is better to use VAProfileH264Main to avoid not decoding.
